### PR TITLE
chore: added tags for resource group

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -37,6 +37,9 @@ param fabricAdminMembers array = []
 @description('Optional. SKU tier of the Fabric resource.')
 param skuName string = 'F2'
 
+@description('Optional. Created by user name.')
+param createdBy string = contains(deployer(), 'userPrincipalName') ? split(deployer().userPrincipalName, '@')[0] : deployer().objectId
+
 var solutionSuffix = toLower(trim(replace(
   replace(
     replace(replace(replace(replace('${solutionName}${solutionUniqueText}', '-', ''), '_', ''), '.', ''), '/', ''),
@@ -46,6 +49,19 @@ var solutionSuffix = toLower(trim(replace(
   '*',
   ''
 )))
+
+// ========== Resource Group Tag ========== //
+resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
+  name: 'default'
+  properties: {
+    tags: {
+      ...resourceGroup().tags
+      TemplateName: 'Unified Data Foundation with Fabric'
+      CreatedBy: createdBy
+      Type: 'Non-WAF'
+    }
+  }
+}
 
 // var userAssignedIdentityResourceName = 'id-${solutionSuffix}'
 // module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.4.1' = {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -54,12 +54,14 @@ var solutionSuffix = toLower(trim(replace(
 resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
   name: 'default'
   properties: {
-    tags: {
-      ...resourceGroup().tags
-      TemplateName: 'Unified Data Foundation with Fabric'
-      CreatedBy: createdBy
-      Type: 'Non-WAF'
-    }
+    tags: union(
+      resourceGroup().tags,
+      {
+        TemplateName: 'Unified Data Foundation with Fabric'
+        CreatedBy: createdBy
+        Type: 'Non-WAF'
+      }
+    )
   }
 }
 


### PR DESCRIPTION
## Purpose
This pull request introduces enhancements to the resource tagging strategy in the `infra/main.bicep` file, aiming to improve traceability and metadata management for deployed resources. The main changes include the addition of a new parameter for capturing the creator's identity and the implementation of a resource group tagging resource.

**Resource Tagging Improvements:**

* Added a new `createdBy` parameter that determines the creator's identity, extracting the username from `userPrincipalName` if available, or falling back to `objectId`.
* Introduced a `resourceGroupTags` resource to apply standardized tags to the resource group, including `TemplateName`, `CreatedBy`, and `Type`, along with any existing tags.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No