### PR TITLE
docs: add option to use existing Fabric capacity in deployment guide

### DIFF
--- a/docs/DeploymentGuideFabric.md
+++ b/docs/DeploymentGuideFabric.md
@@ -439,7 +439,8 @@ Configure the Azure infrastructure components through Bicep template parameters 
 |-----------|-------------------------|------------------------|-------------|---------|---------|
 | **Solution Name** | `solutionName` | `AZURE_ENV_NAME` | Friendly name for the application/solution (3-20 chars) | `udfwfsa` | `mycompany-fabric` |
 | **Location** | `AZURE_LOCATION` | `AZURE_LOCATION` | Azure region for resource deployment | Resource group location | `eastus`, `westus2`, `westeurope` |
-| **Fabric Capacity SKU** | `skuName` | Not directly supported* | Fabric capacity tier and performance level | `F2` | `F4`, `F8`, `F16`, `F32`, `F64`, `F128`, `F256`, `F512`, `F1024`, `F2048` |
+| **Existing Fabric Capacity** *(Optional)* | `AZURE_EXISTING_FABRIC_CAPACITY_NAME` | `AZURE_EXISTING_FABRIC_CAPACITY_NAME` | Name of an existing Fabric capacity to use. If provided, skips capacity creation and uses the specified capacity instead | Empty (creates new capacity) | `fc-mycompany-prod` |
+| **Fabric Capacity SKU** | `skuName` | Not directly supported* | Fabric capacity tier and performance level (only applies when creating new capacity) | `F2` | `F4`, `F8`, `F16`, `F32`, `F64`, `F128`, `F256`, `F512`, `F1024`, `F2048` |
 | **Enable Telemetry** | `enableTelemetry` | Not directly supported* | Enable/disable usage telemetry collection | `true` | `false` |
 
 *GitHub Actions can use additional parameters through Bicep parameter files or workflow modifications.*
@@ -454,6 +455,10 @@ Configure the Azure infrastructure components through Bicep template parameters 
 azd env set AZURE_LOCATION "westeurope"
 azd env set skuName "F8"
 azd env set enableTelemetry false
+
+# Optional: Use an existing Fabric capacity instead of creating a new one
+azd env set AZURE_EXISTING_FABRIC_CAPACITY_NAME "fc-mycompany-prod"
+
 azd up
 ```
 
@@ -479,6 +484,8 @@ Modify [`azure-dev.yml`](../.github/workflows/azure-dev.yml) Deploy Infrastructu
 </details>
 
 **Fabric Capacity SKU Selection Guide:**
+
+> **Note:** SKU selection only applies when creating a new Fabric capacity. If you specify `AZURE_EXISTING_FABRIC_CAPACITY_NAME`, the SKU setting is ignored.
 
 - **F2-F4**: Development and testing environments
 - **F8-F32**: Small to medium production workloads


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates the deployment documentation to clarify how to configure Azure Fabric capacity, including the option to use an existing Fabric capacity instead of always creating a new one. It also explains how the SKU selection behaves in this context and adds an example for setting the new parameter.

Key documentation updates:

**Support for using an existing Fabric capacity:**
- Added a new parameter `AZURE_EXISTING_FABRIC_CAPACITY_NAME` to allow users to specify an existing Fabric capacity, skipping the creation of a new one. The documentation table now includes this parameter and describes its behavior.

**Clarification of SKU parameter usage:**
- Updated the description for the `skuName` parameter to clarify that it only applies when creating a new capacity.
- Added a note in the SKU selection guide explaining that SKU selection is ignored if an existing capacity is specified.

**Example usage:**
- Provided an example showing how to set the `AZURE_EXISTING_FABRIC_CAPACITY_NAME` environment variable to use an existing capacity.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
