### PR TITLE
fix: Sync dev to main - update sales_dashboard SQL endpoint

### DIFF
--- a/fabric_workspace/reports/sales_dashboard.SemanticModel/definition/expressions.tmdl
+++ b/fabric_workspace/reports/sales_dashboard.SemanticModel/definition/expressions.tmdl
@@ -1,4 +1,4 @@
-expression sqlEndpoint = "ccllgusga4suzkb52t4j7lpn7y-igpgb3opinbepkznbwl3f5yqxm.datawarehouse.fabric.microsoft.com" meta [IsParameterQuery = true, IsParameterQueryRequired = true, Type = "Any"]
+expression sqlEndpoint = "ccllgusga4suzkb52t4j7lpn7y-vkiexc7yorzexd6qdusu75hole.datawarehouse.fabric.microsoft.com" meta [IsParameterQuery = true, IsParameterQueryRequired = true, Type = "Any"]
 	lineageTag: 5189c03a-a586-481e-8931-e17cec3c0d5b
 
 	annotation PBI_NavigationStepName = Navigation


### PR DESCRIPTION
## Changes
- Fixed SQL endpoint mismatch in expressions.tmdl for the sales_dashboard semantic model
- Updated the connection string to match the git-integrated workspace's SQL endpoint

## Why
The find_value in parameter.yml was correct but expressions.tmdl had a stale SQL endpoint from a different workspace snapshot. This caused fabric-cicd to silently skip the connection string replacement during deployment.