### PR TITLE
fix: removed the bicep parameter

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -6,7 +6,6 @@ metadata:
 
 requiredVersions:
   azd: ">1.17.1 != 1.23.9"
-  bicep: '>= 0.33.0'
 
 infra:
   provider: bicep


### PR DESCRIPTION
## Purpose
Removed `bicep: '>= 0.33.0'` from the `requiredVersions` section in `azure.yaml`.

Related work items: AB#40862

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How to Test
* Get the code

```ngit clone https://github.com/microsoft/unified-data-foundation-with-fabric-solution-accelerator.git
cd unified-data-foundation-with-fabric-solution-accelerator
git checkout feature/remove-bicep-version
```n
* Test the code
  - Verify `azure.yaml` no longer contains the `bicep` version requirement

## What to Check
Verify that the following are valid
* `azure.yaml` deploys successfully without the bicep version constraint

## Other Information
- Related to ADO User Story #40862
