### PR TITLE
fix: Update Bicep AVM module and API versions for Unified Data Fabric

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -72,7 +72,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2023-07-01' = {
 }
 
 // var userAssignedIdentityResourceName = 'id-${solutionSuffix}'
-// module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.5.0' = {
+// module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.4.1' = {
 //   name: take('avm.res.managed-identity.user-assigned-identity.${userAssignedIdentityResourceName}', 64)
 //   params: {
 //     name: userAssignedIdentityResourceName

--- a/infra/scripts/fabric/install_udf_solution.py
+++ b/infra/scripts/fabric/install_udf_solution.py
@@ -324,7 +324,7 @@ def main() -> None:
     print_step(4, 4, "Running installer notebook",
                notebook_id=notebook_id)
     try:
-        _run_installer_notebook(workspace_client, notebook_id)
+        _run_installer_notebook(workspace_client, notebook_id, max_retries=5, initial_backoff=60)
         print("✅ Successfully completed: run_installer")
         executed_steps.append("run_installer")
     except Exception as exc:


### PR DESCRIPTION
## Summary

Updates Bicep infrastructure code with latest API versions and addresses the unavailable Fabric AVM module issue.

## Changes
- Updated \Microsoft.Resources/tags\ API version from @2021-04-01 to @2023-07-01
- Replaced AVM Fabric capacity module (unavailable from registry) with native \Microsoft.Fabric/capacities@2023-11-01\ resource
- Increased notebook retry logic from 3 to 5 attempts with 60s backoff to handle \GetManagedVnetTimeout\

## Related
User Story #40547: Unified-Data-Fabric - Review and Update Bicep & AVM Module Versions

## Testing
Workflow has been tested and validated - ready for review.