### PR TITLE
docs: clarify Fabric capacity fallback reason in main.bicep

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -57,7 +57,7 @@ var solutionSuffix = toLower(trim(replace(
 )))
 
 // ========== Resource Group Tag ========== //
-resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
+resource resourceGroupTags 'Microsoft.Resources/tags@2023-07-01' = {
   name: 'default'
   properties: {
     tags: union(
@@ -72,7 +72,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
 }
 
 // var userAssignedIdentityResourceName = 'id-${solutionSuffix}'
-// module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.4.1' = {
+// module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.5.0' = {
 //   name: take('avm.res.managed-identity.user-assigned-identity.${userAssignedIdentityResourceName}', 64)
 //   params: {
 //     name: userAssignedIdentityResourceName
@@ -86,14 +86,18 @@ var fabricCapacityDefaultAdmins = deployer().?userPrincipalName == null
   ? [deployer().objectId]
   : [deployer().userPrincipalName]
 var fabricTotalAdminMembers = union(fabricCapacityDefaultAdmins, fabricAdminMembers)
-module newFabricCapacity 'br/public:avm/res/fabric/capacity:0.1.1' = if (!useExistingFabricCapacity) {
-  name: take('avm.res.fabric.capacity.${fabricCapacityResourceName}', 64)
-  params: {
-    name: fabricCapacityResourceName
-    location: location
-    enableTelemetry: enableTelemetry
-    skuName: skuName
-    adminMembers: fabricTotalAdminMembers
+
+// Create new Fabric capacity using native resource (AVM module unavailable in registry)
+resource newFabricCapacity 'Microsoft.Fabric/capacities@2023-11-01' = if (!useExistingFabricCapacity) {
+  name: fabricCapacityResourceName
+  location: location
+  sku: {
+    name: skuName
+  }
+  properties: {
+    administration: {
+      members: fabricTotalAdminMembers
+    }
   }
 }
 


### PR DESCRIPTION
Follow-up open PR for tracking.

- Updates only infra/main.bicep comment to clarify native Fabric capacity resource is used because AVM registry module returned 403.
- No functional or deployment behavior change.