### PR TITLE
revert: Restore AVM module for Fabric capacity creation

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -86,18 +86,14 @@ var fabricCapacityDefaultAdmins = deployer().?userPrincipalName == null
   ? [deployer().objectId]
   : [deployer().userPrincipalName]
 var fabricTotalAdminMembers = union(fabricCapacityDefaultAdmins, fabricAdminMembers)
-
-// Create new Fabric capacity using native resource (AVM module unavailable in registry)
-resource newFabricCapacity 'Microsoft.Fabric/capacities@2023-11-01' = if (!useExistingFabricCapacity) {
-  name: fabricCapacityResourceName
-  location: location
-  sku: {
-    name: skuName
-  }
-  properties: {
-    administration: {
-      members: fabricTotalAdminMembers
-    }
+module newFabricCapacity 'br/public:avm/res/fabric/capacity:0.1.1' = if (!useExistingFabricCapacity) {
+  name: take('avm.res.fabric.capacity.${fabricCapacityResourceName}', 64)
+  params: {
+    name: fabricCapacityResourceName
+    location: location
+    enableTelemetry: enableTelemetry
+    skuName: skuName
+    adminMembers: fabricTotalAdminMembers
   }
 }
 


### PR DESCRIPTION
## Purpose
Reverts the native `Microsoft.Fabric/capacities@2023-11-01` resource back to the AVM module (`br/public:avm/res/fabric/capacity:0.1.1`) as the module change introduced in PR #118 is not required.

## Changes
- Restored `module newFabricCapacity` using AVM registry reference
- Removed native `resource newFabricCapacity` definition
- Re-added `enableTelemetry` and proper `params` block

## Does this introduce a breaking change?
- [x] No

## Notes
Only the Fabric capacity resource definition is reverted. Other changes from PR #118 (API version updates, requirements.txt) are kept as-is.