### PR TITLE
docs: Add Bicep CLI (v0.33.0+) to local deployment prerequisites

### DIFF
--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -30,6 +30,7 @@ Before you begin, ensure you have the following:
 | **Azure subscription** | An active Azure subscription. [Create a free account](https://azure.microsoft.com/free/) if needed. |
 | **Permissions** | Contributor role and RBAC permissions at the subscription level. |
 | **Fabric capacity** | Microsoft Fabric capacity of F64 or higher. |
+| **Bicep CLI** | Bicep CLI version 0.33.0 or higher. [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install). |
 
 For detailed setup instructions, see [Azure Account Setup](./AzureAccountSetUp.md).
 

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -30,7 +30,6 @@ Before you begin, ensure you have the following:
 | **Azure subscription** | An active Azure subscription. [Create a free account](https://azure.microsoft.com/free/) if needed. |
 | **Permissions** | Contributor role and RBAC permissions at the subscription level. |
 | **Fabric capacity** | Microsoft Fabric capacity of F64 or higher. |
-| **Bicep CLI** | Bicep CLI version 0.33.0 or higher. [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install). |
 
 For detailed setup instructions, see [Azure Account Setup](./AzureAccountSetUp.md).
 

--- a/docs/DeploymentGuideFabric.md
+++ b/docs/DeploymentGuideFabric.md
@@ -37,6 +37,7 @@ You need these tools installed to run the deployment commands.
 | Tool | Version | Purpose | Download |
 |------|---------|---------|----------|
 | **Azure Developer CLI** | Latest | Orchestrates deployment | [Install azd](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) |
+| **Bicep CLI** | 0.33.0+ | Compiles infrastructure templates | [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) |
 | **Azure CLI** | Latest | Authentication | [Install az](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | **Python** | 3.9+ | Fabric configuration scripts | [Install Python](https://www.python.org/downloads/) |
 


### PR DESCRIPTION
## Summary

This PR adds the **Bicep CLI** (`v0.33.0+`) as a prerequisite to the local deployment guide of this Generic Solution Accelerator.

The infrastructure-as-code templates in this repository (under `infra/`) require a recent version of the Bicep CLI to compile and deploy successfully via `azd up` / `az deployment`. Without the minimum supported version, users running the deployment locally encounter cryptic compilation errors due to unsupported syntax/features in older Bicep releases.

## Changes

- Added a Bicep CLI (v0.33.0+) entry to the prerequisites list of the local deployment guide, following the **exact format and style** of the existing prerequisite entries (azd, Python, Node.js, etc.) in this repo.

## Why

- Aligns the local deployment guide with the actual minimum Bicep version required by the Bicep templates in this repository.
- Prevents first-run failures for new users provisioning the accelerator from a fresh local environment.
- Brings this accelerator in line with the standard prerequisite set being rolled out across all CSA Generic Solution Accelerators (GSAs).

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Verified the Markdown renders correctly on GitHub (entry appears in the prerequisites list, link resolves to the official Microsoft Learn install page).
- [x] Confirmed the change is scoped to documentation only — no code, infrastructure, or configuration paths are modified.

## Checklist

- [x] My change follows the existing documentation style and formatting of the repository.
- [x] I have performed a self-review of my changes.
- [x] No new warnings, broken links, or formatting issues are introduced.
- [x] No code, configuration, or behavior changes are included in this PR (docs-only).

## Related Work Item

- AB#42634 — `[ALL GSA's] - Add bicep version to the local deployment guide`
