### PR TITLE
fix: Restrict Azure Dev Deploy workflow to manual trigger only and added code to resolve service principal auth issue

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -2,26 +2,6 @@ name: Azure Dev Deploy
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - "infra/**"
-      - "src/**"
-      - "fabric_workspace/**"
-      - "azure.yaml"
-      - "requirements.txt"
-      - ".github/workflows/azure-dev.yml"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "infra/**"
-      - "src/**"
-      - "fabric_workspace/**"
-      - "azure.yaml"
-      - "requirements.txt"
-      - ".github/workflows/azure-dev.yml"
 
 permissions:
   contents: read

--- a/infra/deploy/udf_solution_installer.ipynb
+++ b/infra/deploy/udf_solution_installer.ipynb
@@ -50,7 +50,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install fabric-launcher --quiet\n",
+    "%pip install fabric-launcher -U semantic-link --quiet\n",
     "import notebookutils\n",
     "notebookutils.session.restartPython()"
    ]


### PR DESCRIPTION
This pull request makes two main changes: it updates a dependency installation in the deployment notebook and simplifies the Azure deployment workflow triggers. The most important changes are:

**Azure Deployment Workflow:**

* The `.github/workflows/azure-dev.yml` workflow now only triggers on manual dispatch (`workflow_dispatch`), removing automatic triggers for `push` and `pull_request` events on the `main` branch and specific paths.

**Dependency Management:**

* In `infra/deploy/udf_solution_installer.ipynb`, the `%pip install` command now installs both `fabric-launcher` and upgrades `semantic-link`, ensuring both dependencies are up-to-date before running the notebook.